### PR TITLE
Adds a fix for the "'NoneType' is not iterable" error

### DIFF
--- a/utils/wrapper.py
+++ b/utils/wrapper.py
@@ -172,6 +172,8 @@ class StreamDiffusionWrapper:
             seed=seed,
             engine_dir=engine_dir,
         )
+        
+        self.stream.unet.config.addition_embed_type = None
 
         if device_ids is not None:
             self.stream.unet = torch.nn.DataParallel(


### PR DESCRIPTION
"TypeError: argument of type 'NoneType' is not iterable" when using sdxl-turbo error.
See also https://github.com/cumulo-autumn/StreamDiffusion/issues/20

With this, img2img runs on Windows 11 with Cuda 12.1 and acceleration = none. Didn't test xformers, and tensorrt isn't available yet from the original StreamDiffusion authors.