### PR TITLE
Sdxl unet config fix

### DIFF
--- a/utils/wrapper.py
+++ b/utils/wrapper.py
@@ -173,7 +173,8 @@ class StreamDiffusionWrapper:
             engine_dir=engine_dir,
         )
         
-        self.stream.unet.config.addition_embed_type = None
+        if hasattr(self.stream.unet, 'config'):
+            self.stream.unet.config.addition_embed_type = None
 
         if device_ids is not None:
             self.stream.unet = torch.nn.DataParallel(


### PR DESCRIPTION
Minor addition to #1 
When running sd-turbo with TensorRT acceleration, this config isn't available and you get an error.